### PR TITLE
added 'default todays cost' to admin requests

### DIFF
--- a/app/controllers/pto_requests_controller.rb
+++ b/app/controllers/pto_requests_controller.rb
@@ -43,7 +43,7 @@ class PtoRequestsController < ApplicationController
 
         if @pto_request.reason == 'make up / sick day'
             return add_make_up_day
-        end 
+        end
         
         if @user.on_pip == true && @user.id == current_user.id
             return redirect_to root_path, notice: "You're PTO is currently restricted, please talk to your supervisor"
@@ -68,6 +68,10 @@ class PtoRequestsController < ApplicationController
 
         if @user.bank_value < @pto_request.cost
             return  redirect_to root_path, notice: "You do not have enough to make this request"
+        end
+
+        if @pto_request.cost == -1
+            @pto_request.cost = @calendar.current_price
         end
         
         if @pto_request.save

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -114,7 +114,7 @@
                             class: 'form-control', 
                             required: 'true' %>
                         <%= f.date_field :request_date %>
-                        <%= f.number_field :cost %>
+                        <%= f.number_field :cost, placeholder: 'place -1 to use todays cost' %>
                         <%= f.submit 'create request', class: 'form-control' %>
                     <% end %>
                     </div> <!-- modal-body -->


### PR DESCRIPTION
closes #98 

test plan: 

from `/users/:id` as an admin create a request for a user using the value -1. the request should default to the calendars.current_cost 