### PR TITLE
move outbound address to env var - issue #140

### DIFF
--- a/app/mailers/coverage_mailer.rb
+++ b/app/mailers/coverage_mailer.rb
@@ -1,5 +1,5 @@
 class CoverageMailer < ApplicationMailer
-  default from: 'supportpanda@instructure.com'
+  default from: ENV['APP_FROM_EMAIL']
 
   def off_today
     mail(to: ENV['MCO_EMAIL'], subject: "Agents off today: #{Date.today.strftime("%A, %Y-%m-%d")}")

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -1,5 +1,5 @@
 class RegistrationMailer < ApplicationMailer
-    default from: 'supportpanda@instructure.com'
+    default from: ENV['APP_FROM_EMAIL']
 
     def registration_email
         @user = params[:user]

--- a/app/mailers/requests_mailer.rb
+++ b/app/mailers/requests_mailer.rb
@@ -1,5 +1,5 @@
 class RequestsMailer < ApplicationMailer
-    default from: 'supportpanda@instructure.com'
+    default from: ENV['APP_FROM_EMAIL']
 
     before_action :get_params, only: %i[requests_email delete_request_email admin_request_email excuse_request_email sick_make_up_email zero_credit_email missed_holiday_email no_call_show_email]
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -19,7 +19,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'supportpanda@instructure.com'
+  config.mailer_sender = ENV['APP_FROM_EMAIL']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/db/migrate/20190327003202_add_position_to_agent.rb
+++ b/db/migrate/20190327003202_add_position_to_agent.rb
@@ -1,9 +1,0 @@
-class AddPositionToAgent < ActiveRecord::Migration[5.2]
-  def change
-    add_column :agents, :position, :string
-    add_column :agents, :team, :string
-    add_column :agents, :start_time, :string
-    add_column :agents, :end_time, :string
-    add_column :agents, :work_days, :string
-  end
-end

--- a/db/migrate/20190327015832_add_admin_to_agent.rb
+++ b/db/migrate/20190327015832_add_admin_to_agent.rb
@@ -1,5 +1,0 @@
-class AddAdminToAgent < ActiveRecord::Migration[5.2]
-  def change
-    add_column :agents, :admin, :boolean
-  end
-end

--- a/db/migrate/20190506201016_add_start_date_to_agent.rb
+++ b/db/migrate/20190506201016_add_start_date_to_agent.rb
@@ -1,5 +1,0 @@
-class AddStartDateToAgent < ActiveRecord::Migration[5.2]
-  def change
-    add_column :agents, :start_date, :datetime
-  end
-end

--- a/db/migrate/20190508195442_drop_agents.rb
+++ b/db/migrate/20190508195442_drop_agents.rb
@@ -1,5 +1,0 @@
-class DropAgents < ActiveRecord::Migration[5.2]
-  def change
-    drop_table :agents
-  end
-end

--- a/db/migrate/20190508195510_drop_date_values.rb
+++ b/db/migrate/20190508195510_drop_date_values.rb
@@ -1,5 +1,0 @@
-class DropDateValues < ActiveRecord::Migration[5.2]
-  def change
-    drop_table :date_values
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_08_195510) do
+ActiveRecord::Schema.define(version: 2019_05_06_200310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
NOTE: This will require the addition of an env var 'APP_FROM_EMAIL' to be set to desired outbound address and should be the same account as the existing Gmail authentication Env Vars

closes #140 
Test Plan

**ensure email sent from new address**
1.Add Env variable 'APP_FROM_EMAIL'
2.Set to desired outbound address
3.Upload New User
4.Check Sent Folders - ensure new registration emails are sent