### PR TITLE
Agents-table width matches working-grid

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -217,7 +217,7 @@ form[enctype="multipart/form-data"] {
   height: 95%;
   background-color: white;
   color: $header;
-  width: 100%;
+  width: 1050px;
   padding-bottom: 20px;
 }
 


### PR DESCRIPTION
Padding on Agents-Table hid content because horizontal scroll is connected to working-grid instead. This change makes the Agents-table width and the working-grid width the same to prevent 'floating scrollbar' and make all agents-table content visible for any browser width. 

issue #105 